### PR TITLE
Fixing directory permissions (octal instead than decimal)

### DIFF
--- a/src/OpenBook/BookGenerator.php
+++ b/src/OpenBook/BookGenerator.php
@@ -356,7 +356,7 @@ class BookGenerator
             
             $dirName = dirname($outFile);
             if (!is_dir($dirName)) {
-                mkdir($dirName, '0775', true);
+                mkdir($dirName, 0775, true);
             }
             
             $this->log("Generating chapter: $outFile\n");
@@ -513,7 +513,7 @@ class BookGenerator
         $count = 0;
         foreach ($this->filesToCopy as $srcFile=>$dstFile) {
             if(!is_dir(dirname($dstFile)))
-                mkdir(dirname($dstFile), '775', true);
+                mkdir(dirname($dstFile), 775, true);
             if(!is_readable($srcFile)) {
                 $this->warnings[] = 'Failed to copy file: ' . $srcFile;
                 $this->log('Failed to copy file: ' . $srcFile . "\n");


### PR DESCRIPTION
Hi again! I have been trying to generate your book's HTML code on my machine but I got problems with the directory permission. Please note that mkdir (and other functions like umask & co) use octal permission, while the strings that you've used, '0755' and '755' get interpreted as decimal numbers (you can see it by yourself by evaluating '0755' \* 1 or something like that).
